### PR TITLE
parse cli tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Command-line tool for converting **anything** to JSON.
 ## Features
 
 * Eat everything, spits out json
-* Supports **json**, **yaml**, **toml**, **xml**, **ini**
+* Supports **json**, **yaml**, **toml**, **xml**, **ini**, **cli tables**
 * Formatting and highlighting
 * Standalone binary
 
@@ -26,6 +26,8 @@ $ eat resp.xml > resp.json
 $ cat config.yaml | eat > config.json
 
 $ eat deps.toml
+
+$ ps | eat | fx .PID
 ```
 
 ### Other examples

--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ const cli = meow(`
 
   Examples
     $ eat resp.xml > resp.json
-    
+
     $ cat config.yaml | eat > config.json
-    
+
     $ eat deps.toml
 
 `)
@@ -47,6 +47,7 @@ const decoders = [
   decodeYAML,
   decodeTOML,
   decodeINI,
+  decodeCLITable,
 ]
 
 function decodeJSON(text) {
@@ -70,7 +71,14 @@ function decodeTOML(text) {
 }
 
 function decodeINI(text) {
-  return require('ini').parse(text)
+  if (!/^\[.*\]$/.test(text)) throw 'not ini'
+
+  return  require('ini').parse(text)
+}
+
+function decodeCLITable(text) {
+  const [header, ...data] = text.replace(/\n$/,'m').split('\n').map(x => x.split(/\s+/))
+  return data.map(line => line.reduce((a, v, i) => { if (v || header[i]) a[header[i]] = v; return a }, {}))
 }
 
 function decode(text) {


### PR DESCRIPTION
Parse standard cli tables like `ps`, `docker images`:
```
$ ps | eat

[
  {
    "PID": "5424",
    "TTY": "pts/1",
    "TIME": "00:00:00",
    "CMD": "fish"
  },
  {
    "PID": "6183",
    "TTY": "pts/1",
    "TIME": "00:00:00",
    "CMD": "ps"
  },
  {
    "PID": "6184",
    "TTY": "pts/1",
    "TIME": "00:00:00",
    "CMD": "node"
  },
  {
    "PID": "6185",
    "TTY": "pts/1",
    "TIME": "00:00:00",
    "CMD": "xclipm"
  }
]

```
