### PR TITLE
trim ws on cli table lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function decodeINI(text) {
 }
 
 function decodeCLITable(text) {
-  const [header, ...data] = text.replace(/\n$/,'m').split('\n').map(x => x.split(/\s+/))
+  const [header, ...data] = text.replace(/\n$/, '').split('\n').map(x => x.replace(/^\s+|\s+$/, '').split(/\s+/))
   return data.map(line => line.reduce((a, v, i) => { if (v || header[i]) a[header[i]] = v; return a }, {}))
 }
 


### PR DESCRIPTION
On my system, `ps` output looks like:

```
§ ps | head
  PID TTY          TIME CMD
 4634 pts/24   00:00:00 zsh
13998 pts/24   00:00:00 ps
13999 pts/24   00:00:00 head
```

Notice leading whitespace on some columns in order to right-align numbers. These leading spaces result in output like this when piped through `eat`:

```
§ ps | head | eat
{
  "PID TTY          TIME CMD": true,
  "4634 pts/24   00:00:01 zsh": true,
  "22243 pts/24   00:00:00 ps": true,
  "22251 pts/24   00:00:00 head": true,
  "22252 pts/24   00:00:00 node": true
}
```

This is due to the leading spaces adding extra columns, which makes it seem like all lines don't have the same number of columns. Stripping leading and trailing whitespace fixes that for this and any similar cli tables.

NOTE: Also, I think you had a typo where you were replacing the last newline with the letter `'m'`, so I converted that to the empty `''` that I assume you meant.